### PR TITLE
Cache prompt repair product memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ This feature is experimental and lives in the benchmark harness today:
 python3 benchmark/prompt_improvement.py --dry-run
 ```
 
+`anchor build` also writes `.anchor/product_memory.json` with deterministic
+product facts extracted from the README, prompt-repair docs, and manifests.
+
 See [Project-Aware Prompt Repair](docs/prompt-repair.md) for the workflow,
 planned CLI, and benchmark strategy.
 

--- a/docs/prompt-repair.md
+++ b/docs/prompt-repair.md
@@ -18,6 +18,8 @@ What exists today:
 - prompt cases in `benchmark/prompt_cases.example.jsonl`
 - deterministic repo profiling from files, manifests, symbols, and `.anchor`
   indexes when available
+- `anchor build` writes `.anchor/product_memory.json` with source-cited facts
+  from local docs and manifests
 - local Ollama smoke testing for raw prompt vs repaired prompt
 
 What is not implemented yet:
@@ -78,6 +80,7 @@ anchor build
   -> .anchor/index/paths.json
   -> .anchor/index/symbols.json
   -> .anchor/index/calls.json
+  -> .anchor/product_memory.json
   -> .anchor/project_profile.json
 
 anchor prompt repair "<human prompt>"

--- a/src/bin/cli_parts/build.rs
+++ b/src/bin/cli_parts/build.rs
@@ -9,6 +9,7 @@ struct BuildStats {
     call_count: usize,
     history_commits: usize,
     history_edges: usize,
+    product_memory_facts: usize,
 }
 
 fn cmd_build(root: &Path) -> Result<()> {
@@ -152,6 +153,8 @@ fn build_indexes(root: &Path) -> Result<BuildStats> {
     store.save_call_index(&call_index)?;
     let history_index = build_history_index(root);
     store.save_history_index(&history_index)?;
+    let product_memory = build_product_memory(root);
+    store.save_product_memory(&product_memory)?;
 
     let indexed = results.len();
     let skipped = files.len() - indexed;
@@ -159,6 +162,7 @@ fn build_indexes(root: &Path) -> Result<BuildStats> {
     let call_count = call_index.calls.values().map(|v| v.len()).sum::<usize>();
     let history_commits = history_index.commits_scanned;
     let history_edges = history_index.cochanges.len();
+    let product_memory_facts = product_memory.facts.len();
 
     Ok(BuildStats {
         indexed,
@@ -167,6 +171,164 @@ fn build_indexes(root: &Path) -> Result<BuildStats> {
         call_count,
         history_commits,
         history_edges,
+        product_memory_facts,
     })
 }
 
+fn build_product_memory(root: &Path) -> anchor::storage::ProductMemory {
+    const SOURCES: [&str; 3] = ["README.md", "docs/prompt-repair.md", "Cargo.toml"];
+
+    let mut facts = Vec::new();
+    let mut source_bytes = Vec::new();
+
+    for source in SOURCES {
+        let path = root.join(source);
+        let Ok(contents) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        source_bytes.extend_from_slice(source.as_bytes());
+        source_bytes.extend_from_slice(contents.as_bytes());
+
+        for fact in product_memory_candidates(source, &contents) {
+            facts.push(anchor::storage::ProductMemoryEntry {
+                source: source.to_string(),
+                fact,
+            });
+        }
+    }
+
+    facts.sort_by(|a, b| a.source.cmp(&b.source).then_with(|| a.fact.cmp(&b.fact)));
+    let mut seen = std::collections::HashSet::new();
+    facts.retain(|fact| seen.insert((fact.source.clone(), fact.fact.clone())));
+
+    anchor::storage::ProductMemory {
+        schema: "anchor.product_memory.v1".to_string(),
+        source_hash: if source_bytes.is_empty() {
+            String::new()
+        } else {
+            anchor::storage::content_hash(&source_bytes)
+        },
+        facts,
+    }
+}
+
+fn product_memory_candidates(source: &str, contents: &str) -> Vec<String> {
+    match source {
+        "README.md" | "docs/prompt-repair.md" => markdown_fact_candidates(contents),
+        "Cargo.toml" => manifest_fact_candidates(contents),
+        _ => Vec::new(),
+    }
+}
+
+fn markdown_fact_candidates(contents: &str) -> Vec<String> {
+    let mut facts = Vec::new();
+    let mut paragraph = Vec::new();
+    let mut in_code_block = false;
+
+    let flush_paragraph = |paragraph: &mut Vec<String>, facts: &mut Vec<String>| {
+        if paragraph.is_empty() {
+            return;
+        }
+        let joined = paragraph.join(" ");
+        if let Some(fact) = normalize_product_fact(&joined) {
+            facts.push(fact);
+        }
+        paragraph.clear();
+    };
+
+    for line in contents.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("```") {
+            flush_paragraph(&mut paragraph, &mut facts);
+            in_code_block = !in_code_block;
+            continue;
+        }
+        if in_code_block {
+            continue;
+        }
+        if trimmed.is_empty() {
+            flush_paragraph(&mut paragraph, &mut facts);
+            continue;
+        }
+        if trimmed.starts_with('#') {
+            flush_paragraph(&mut paragraph, &mut facts);
+            continue;
+        }
+        if let Some(bullet) = trimmed.strip_prefix("- ").or_else(|| trimmed.strip_prefix("* ")) {
+            flush_paragraph(&mut paragraph, &mut facts);
+            if let Some(fact) = normalize_product_fact(bullet) {
+                facts.push(fact);
+            }
+            continue;
+        }
+        paragraph.push(trimmed.to_string());
+    }
+
+    flush_paragraph(&mut paragraph, &mut facts);
+    facts
+}
+
+fn manifest_fact_candidates(contents: &str) -> Vec<String> {
+    let mut facts = Vec::new();
+    for line in contents.lines() {
+        let trimmed = line.trim();
+        if let Some(value) = trimmed.strip_prefix("description = ") {
+            if let Some(fact) = normalize_product_fact(&format!(
+                "Cargo package description: {}",
+                value.trim_matches('"')
+            )) {
+                facts.push(fact);
+            }
+        } else if let Some(value) = trimmed.strip_prefix("keywords = [") {
+            let keywords = value.trim_end_matches(']').replace('"', "");
+            if let Some(fact) =
+                normalize_product_fact(&format!("Cargo package keywords: {}", keywords.trim()))
+            {
+                facts.push(fact);
+            }
+        }
+    }
+    facts
+}
+
+fn normalize_product_fact(text: &str) -> Option<String> {
+    let normalized = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    if normalized.len() < 24 {
+        return None;
+    }
+
+    let first_sentence = normalized
+        .split_terminator(". ")
+        .next()
+        .unwrap_or(&normalized)
+        .trim();
+    let mut fact = if first_sentence.len() >= 24 {
+        first_sentence.to_string()
+    } else {
+        normalized
+    };
+
+    if fact.len() > 180 {
+        fact.truncate(177);
+        fact.push_str("...");
+    }
+
+    is_product_fact(&fact.to_lowercase()).then_some(fact)
+}
+
+fn is_product_fact(fact: &str) -> bool {
+    [
+        "anchor",
+        "prompt repair",
+        "repo-local",
+        "coding agents",
+        "checked write",
+        ".anchor",
+        "lockd",
+        "llm",
+        "experimental",
+        "reindex",
+    ]
+    .iter()
+    .any(|needle| fact.contains(needle))
+}

--- a/src/bin/cli_parts/history_store.rs
+++ b/src/bin/cli_parts/history_store.rs
@@ -152,9 +152,10 @@ fn print_build_stats(stats: BuildStats) {
         call_count,
         history_commits,
         history_edges,
+        product_memory_facts,
     } = stats;
     println!(
-        "<build>\n<files>{indexed}</files>\n<symbols>{sym_count}</symbols>\n<calls>{call_count}</calls>\n<history_commits>{history_commits}</history_commits>\n<history_edges>{history_edges}</history_edges>\n<skipped_files>{skipped}</skipped_files>\n</build>"
+        "<build>\n<files>{indexed}</files>\n<symbols>{sym_count}</symbols>\n<calls>{call_count}</calls>\n<history_commits>{history_commits}</history_commits>\n<history_edges>{history_edges}</history_edges>\n<product_memory_facts>{product_memory_facts}</product_memory_facts>\n<skipped_files>{skipped}</skipped_files>\n</build>"
     );
 }
 

--- a/src/storage/anchor.rs
+++ b/src/storage/anchor.rs
@@ -125,6 +125,19 @@ pub struct PathHistoryEntry {
     pub is_test: bool,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProductMemory {
+    pub schema: String,
+    pub source_hash: String,
+    pub facts: Vec<ProductMemoryEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProductMemoryEntry {
+    pub source: String,
+    pub fact: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Projection {
     pub path: String,

--- a/src/storage/anchor_parts/index_io.rs
+++ b/src/storage/anchor_parts/index_io.rs
@@ -116,4 +116,27 @@ impl AnchorStore {
         };
         serde_json::from_slice(&bytes).unwrap_or_default()
     }
+
+    pub fn product_memory_path(&self) -> PathBuf {
+        self.anchor_root.join("product_memory.json")
+    }
+
+    pub fn save_product_memory(&self, memory: &ProductMemory) -> Result<()> {
+        let path = self.product_memory_path();
+        fs::create_dir_all(path.parent().ok_or_else(|| {
+            AnchorError::InvalidStructure(format!(
+                "product memory has no parent: {}",
+                path.display()
+            ))
+        })?)?;
+        fs::write(path, serde_json::to_vec_pretty(memory)?)?;
+        Ok(())
+    }
+
+    pub fn load_product_memory(&self) -> ProductMemory {
+        let Ok(bytes) = fs::read(self.product_memory_path()) else {
+            return ProductMemory::default();
+        };
+        serde_json::from_slice(&bytes).unwrap_or_default()
+    }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -10,5 +10,6 @@ pub(crate) mod bm25;
 
 pub use anchor::{
     content_hash, AnchorStore, CallIndex, CoChangeEntry, HistoryIndex, HistoryNeighbor, ObjectKind,
-    PathEntry, PathHistoryEntry, PathIndex, Projection, SymbolEntry, SymbolIndex, ANCHOR_DIR,
+    PathEntry, PathHistoryEntry, PathIndex, ProductMemory, ProductMemoryEntry, Projection,
+    SymbolEntry, SymbolIndex, ANCHOR_DIR,
 };

--- a/tests/test_cli_build_parts/part5.rs
+++ b/tests/test_cli_build_parts/part5.rs
@@ -69,3 +69,89 @@ fn cli_context_truncates_large_default_symbol_output() {
     assert!(stdout.contains("context truncated"), "{stdout}");
     assert!(!stdout.contains("print(179)"), "{stdout}");
 }
+
+#[test]
+fn cli_build_writes_product_memory_cache_from_local_docs() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::create_dir_all(dir.path().join("docs")).unwrap();
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        "[package]\nname = \"anchor-fixture\"\nversion = \"0.1.0\"\ndescription = \"Repo-local execution harness for coding AI agents.\"\nkeywords = [\"ai\", \"agents\", \"coding\"]\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join("README.md"),
+        "# Anchor Fixture\n\nAnchor is a repo-local execution harness for coding agents working inside real codebases.\n\nAnchor writes its local index to `.anchor/`.\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join("docs/prompt-repair.md"),
+        "# Prompt Repair\n\nPrompt Repair is experimental.\n\nThe default path should not call an LLM.\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join("src.py"),
+        "def login():\n    return True\n",
+    )
+    .unwrap();
+
+    let anchor = env!("CARGO_BIN_EXE_anchor");
+    let build = Command::new(anchor)
+        .arg("--root")
+        .arg(dir.path())
+        .arg("build")
+        .output()
+        .unwrap();
+    assert!(
+        build.status.success(),
+        "build failed: {}\n{}",
+        String::from_utf8_lossy(&build.stderr),
+        String::from_utf8_lossy(&build.stdout)
+    );
+
+    let stdout = String::from_utf8_lossy(&build.stdout);
+    assert!(stdout.contains("<product_memory_facts>"), "{stdout}");
+
+    let memory_path = dir.path().join(".anchor/product_memory.json");
+    let memory: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&memory_path).unwrap()).unwrap();
+    assert_eq!(memory["schema"], "anchor.product_memory.v1", "{memory}");
+    assert!(
+        memory["source_hash"]
+            .as_str()
+            .map(|value| !value.is_empty())
+            .unwrap_or(false),
+        "{memory}"
+    );
+    let facts = memory["facts"].as_array().unwrap();
+    assert!(
+        facts.iter().any(|fact| {
+            fact["source"] == "README.md"
+                && fact["fact"]
+                    .as_str()
+                    .unwrap_or("")
+                    .contains("repo-local execution harness")
+        }),
+        "{memory}"
+    );
+    assert!(
+        facts.iter().any(|fact| {
+            fact["source"] == "docs/prompt-repair.md"
+                && fact["fact"]
+                    .as_str()
+                    .unwrap_or("")
+                    .contains("should not call an LLM")
+        }),
+        "{memory}"
+    );
+    assert!(
+        facts.iter().any(|fact| {
+            fact["source"] == "Cargo.toml"
+                && fact["fact"]
+                    .as_str()
+                    .unwrap_or("")
+                    .contains("coding AI agents")
+        }),
+        "{memory}"
+    );
+}


### PR DESCRIPTION
## Summary
- cache deterministic prompt-repair product facts in `.anchor/product_memory.json` during `anchor build`
- add `AnchorStore` plumbing for reading and writing product-memory snapshots
- document the new cache and add a build integration test that checks README/docs/manifest evidence

## Validation
- Not run: `cargo fmt --check` (`cargo` is not installed in this environment)
- Not run: `cargo test --test test_cli_build cli_build_writes_product_memory_cache_from_local_docs -- --exact` (`cargo` is not installed in this environment)

## Notes
- `origin/dev` does not include the prompt CLI yet, so this slice targets shared build-time memory plumbing rather than prompt output rendering.
