### PR TITLE
Persist prompt repair project profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,10 @@ fix the agent locks thing so two ais dont mess up the same file lol
 Anchor can repair that into a task brief that points at the actual lock paths,
 warns against invented tools, and suggests checks to run.
 
-This feature is experimental and lives in the benchmark harness today:
+This feature is experimental and lives in the benchmark harness today. `anchor build` now caches repo facts for it in `.anchor/project_profile.json`:
 
 ```bash
+anchor build
 python3 benchmark/prompt_improvement.py --dry-run
 ```
 

--- a/benchmark/prompt_improvement.py
+++ b/benchmark/prompt_improvement.py
@@ -272,6 +272,31 @@ def load_anchor_index(root: Path) -> tuple[list[str], list[str]]:
     return sorted(indexed_files), symbols[:120]
 
 
+def load_cached_profile(root: Path) -> ProjectProfile | None:
+    path = root / ".anchor" / "project_profile.json"
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+    indexed_files, indexed_symbols = load_anchor_index(root)
+    cached_files = data.get("indexed_files")
+    profile_files = [Path(item) for item in cached_files] if isinstance(cached_files, list) else []
+    files = profile_files or repo_files(root)
+    return ProjectProfile(
+        root=str(root),
+        languages=[item for item in data.get("languages", []) if isinstance(item, str)],
+        top_dirs=[item for item in data.get("top_dirs", []) if isinstance(item, str)],
+        key_files=[item for item in data.get("key_files", []) if isinstance(item, str)],
+        indexed_files=[item for item in data.get("indexed_files", indexed_files) if isinstance(item, str)],
+        manifest_files=[item for item in data.get("manifests", []) if isinstance(item, str)],
+        test_commands=[item for item in data.get("test_commands", []) if isinstance(item, str)],
+        symbols=indexed_symbols or extract_symbols(root, files),
+    )
+
+
 def extract_symbols(root: Path, files: list[Path], limit: int = 120) -> list[str]:
     patterns = [
         re.compile(r"^\s*(?:pub\s+)?(?:async\s+)?fn\s+([A-Za-z_][A-Za-z0-9_]*)"),
@@ -310,6 +335,10 @@ def split_tokens(text: str) -> set[str]:
 
 
 def build_profile(root: Path) -> ProjectProfile:
+    cached = load_cached_profile(root)
+    if cached is not None:
+        return cached
+
     files = repo_files(root)
     indexed_files, indexed_symbols = load_anchor_index(root)
     language_counts = Counter(

--- a/docs/prompt-repair.md
+++ b/docs/prompt-repair.md
@@ -18,12 +18,12 @@ What exists today:
 - prompt cases in `benchmark/prompt_cases.example.jsonl`
 - deterministic repo profiling from files, manifests, symbols, and `.anchor`
   indexes when available
+- cached `.anchor/project_profile.json` snapshots generated during `anchor build`
 - local Ollama smoke testing for raw prompt vs repaired prompt
 
 What is not implemented yet:
 
 - no compiled `anchor prompt` CLI command yet
-- no persistent `.anchor/project_profile.json` yet
 - no LLM call in the default repair path
 - no patch-level benchmark yet
 
@@ -140,8 +140,10 @@ Suggested fields:
 }
 ```
 
-The profile should be rebuilt only when relevant inputs change. Prompt-time work
-should be limited to reading this profile plus the existing symbol index.
+The profile should be rebuilt only when relevant inputs change. `anchor build`
+now writes this snapshot, and the prompt benchmark reuses it when present.
+Prompt-time work should stay limited to reading this profile plus the existing
+symbol index.
 
 ## Repair Pipeline
 

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -12,7 +12,8 @@ use anchor::lock::lockd;
 use anchor::parser::language::is_indexable_text_path;
 use anchor::query::slice::slice_code;
 use anchor::storage::{
-    content_hash, AnchorStore, CallIndex, HistoryIndex, PathIndex, SymbolEntry, SymbolIndex,
+    content_hash, AnchorStore, CallIndex, HistoryIndex, PathIndex, ProjectProfile, SymbolEntry,
+    SymbolIndex,
 };
 use anyhow::{bail, Result};
 use clap::Parser;

--- a/src/bin/cli_parts/build.rs
+++ b/src/bin/cli_parts/build.rs
@@ -30,6 +30,11 @@ fn build_indexes(root: &Path) -> Result<BuildStats> {
         .filter(|e| is_indexable_text_path(e.path()))
         .map(|e| e.into_path())
         .collect();
+    let indexed_files = files
+        .iter()
+        .filter_map(|path| path.strip_prefix(root).ok())
+        .map(|path| path.to_string_lossy().replace('\\', "/"))
+        .collect::<Vec<_>>();
 
     // Parse all files in parallel — read-only, no shared writes
     let results: Vec<_> = files
@@ -152,6 +157,8 @@ fn build_indexes(root: &Path) -> Result<BuildStats> {
     store.save_call_index(&call_index)?;
     let history_index = build_history_index(root);
     store.save_history_index(&history_index)?;
+    let project_profile = build_project_profile(root, &indexed_files, symbol_index.symbols.len())?;
+    store.save_project_profile(&project_profile)?;
 
     let indexed = results.len();
     let skipped = files.len() - indexed;
@@ -170,3 +177,170 @@ fn build_indexes(root: &Path) -> Result<BuildStats> {
     })
 }
 
+fn build_project_profile(
+    root: &Path,
+    indexed_files: &[String],
+    indexed_symbols: usize,
+) -> Result<ProjectProfile> {
+    use std::collections::BTreeMap;
+    use std::fs;
+
+    let mut language_counts: BTreeMap<&'static str, usize> = BTreeMap::new();
+    let mut dir_counts: BTreeMap<String, usize> = BTreeMap::new();
+    let mut fingerprint = String::new();
+
+    for file in indexed_files {
+        if let Some(language) = profile_language_name(file) {
+            *language_counts.entry(language).or_default() += 1;
+        }
+        if let Some((first, _)) = file.split_once('/') {
+            *dir_counts.entry(first.to_string()).or_default() += 1;
+        }
+        let bytes = fs::read(root.join(file))?;
+        fingerprint.push_str(file);
+        fingerprint.push('\n');
+        fingerprint.push_str(&content_hash(&bytes));
+        fingerprint.push('\n');
+    }
+
+    let (frameworks_present, frameworks_absent) = detect_frameworks(root);
+
+    Ok(ProjectProfile {
+        schema: "anchor.project_profile.v1".to_string(),
+        source_hash: content_hash(fingerprint.as_bytes()),
+        languages: sorted_counts(language_counts),
+        manifests: existing_paths(
+            root,
+            &[
+                "Cargo.toml",
+                "Cargo.lock",
+                "lockd/go.mod",
+                "lockd/go.sum",
+                "package.json",
+                "pyproject.toml",
+                "requirements.txt",
+                "pytest.ini",
+                "go.mod",
+            ],
+        ),
+        key_files: existing_paths(
+            root,
+            &[
+                "README.md",
+                "Cargo.toml",
+                "package.json",
+                "docs/prompt-repair.md",
+                "src/bin/cli.rs",
+                "src/storage/anchor.rs",
+                "src/storage/bm25.rs",
+                "src/cache.rs",
+            ],
+        ),
+        top_dirs: sorted_counts(dir_counts),
+        test_commands: detect_test_commands(root),
+        indexed_files: indexed_files.to_vec(),
+        frameworks_present,
+        frameworks_absent,
+        entrypoints: existing_paths(
+            root,
+            &[
+                "src/bin/cli.rs",
+                "main.go",
+                "lockd/main.go",
+                "manage.py",
+                "package.json",
+            ],
+        ),
+        indexed_symbols,
+    })
+}
+
+fn detect_test_commands(root: &Path) -> Vec<String> {
+    let mut commands = Vec::new();
+    if root.join("Cargo.toml").exists() {
+        commands.push("cargo test".to_string());
+        commands.push("cargo build --release".to_string());
+    }
+    if root.join("lockd/go.mod").exists() {
+        commands.push("cd lockd && go test ./...".to_string());
+    } else if root.join("go.mod").exists() {
+        commands.push("go test ./...".to_string());
+    }
+    if root.join("package.json").exists() {
+        commands.push("npm test".to_string());
+    }
+    if root.join("pyproject.toml").exists() || root.join("pytest.ini").exists() {
+        commands.push("pytest".to_string());
+    }
+    if root.join("docs/install.sh").exists() && root.join("docs/uninstall.sh").exists() {
+        commands.push("bash -n docs/install.sh docs/uninstall.sh local_install.sh".to_string());
+    }
+    commands
+}
+
+fn detect_frameworks(root: &Path) -> (Vec<String>, Vec<String>) {
+    let known = ["express", "jest", "react", "next"];
+    let package_text = std::fs::read_to_string(root.join("package.json"))
+        .unwrap_or_default()
+        .to_lowercase();
+    let next_config_present =
+        root.join("next.config.js").exists() || root.join("next.config.ts").exists();
+    let mut present = Vec::new();
+
+    for framework in known {
+        let found = match framework {
+            "next" => next_config_present || package_text.contains("\"next\""),
+            _ => package_text.contains(&format!("\"{framework}\"")),
+        };
+        if found {
+            present.push(framework.to_string());
+        }
+    }
+
+    let absent = known
+        .iter()
+        .filter(|framework| !present.iter().any(|item| item == *framework))
+        .map(|framework| (*framework).to_string())
+        .collect();
+
+    (present, absent)
+}
+
+fn existing_paths(root: &Path, candidates: &[&str]) -> Vec<String> {
+    candidates
+        .iter()
+        .filter(|path| root.join(path).exists())
+        .map(|path| (*path).to_string())
+        .collect()
+}
+
+fn profile_language_name(path: &str) -> Option<&'static str> {
+    match Path::new(path).extension().and_then(|ext| ext.to_str()) {
+        Some("rs") => Some("Rust"),
+        Some("py") | Some("pyw") => Some("Python"),
+        Some("js") | Some("mjs") | Some("cjs") => Some("JavaScript"),
+        Some("ts") | Some("mts") | Some("cts") => Some("TypeScript"),
+        Some("tsx") | Some("jsx") => Some("TSX"),
+        Some("go") => Some("Go"),
+        Some("java") => Some("Java"),
+        Some("cs") => Some("C#"),
+        Some("rb") => Some("Ruby"),
+        Some("cpp") | Some("cc") | Some("cxx") | Some("hpp") | Some("h") => Some("C++"),
+        Some("swift") => Some("Swift"),
+        Some("md") | Some("mdx") => Some("Markdown"),
+        Some("toml") => Some("TOML"),
+        Some("json") => Some("JSON"),
+        Some("yaml") | Some("yml") => Some("YAML"),
+        Some("csv") => Some("CSV"),
+        _ => None,
+    }
+}
+
+fn sorted_counts<T>(counts: std::collections::BTreeMap<T, usize>) -> Vec<T>
+where
+    T: Ord,
+{
+    let mut items = counts.into_iter().collect::<Vec<_>>();
+    items.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    items.into_iter().map(|(item, _)| item).take(8).collect()
+}

--- a/src/storage/anchor.rs
+++ b/src/storage/anchor.rs
@@ -99,6 +99,31 @@ pub struct HistoryIndex {
     pub paths: Vec<PathHistoryEntry>,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProjectProfile {
+    pub schema: String,
+    pub source_hash: String,
+    #[serde(default)]
+    pub languages: Vec<String>,
+    #[serde(default)]
+    pub manifests: Vec<String>,
+    #[serde(default)]
+    pub key_files: Vec<String>,
+    #[serde(default)]
+    pub top_dirs: Vec<String>,
+    #[serde(default)]
+    pub test_commands: Vec<String>,
+    #[serde(default)]
+    pub indexed_files: Vec<String>,
+    #[serde(default)]
+    pub frameworks_present: Vec<String>,
+    #[serde(default)]
+    pub frameworks_absent: Vec<String>,
+    #[serde(default)]
+    pub entrypoints: Vec<String>,
+    pub indexed_symbols: usize,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CoChangeEntry {
     pub path: String,

--- a/src/storage/anchor_parts/index_io.rs
+++ b/src/storage/anchor_parts/index_io.rs
@@ -116,4 +116,30 @@ impl AnchorStore {
         };
         serde_json::from_slice(&bytes).unwrap_or_default()
     }
+
+    pub fn project_profile_path(&self) -> PathBuf {
+        self.anchor_root.join("project_profile.json")
+    }
+
+    pub fn save_project_profile(&self, profile: &ProjectProfile) -> Result<()> {
+        let path = self.project_profile_path();
+        fs::create_dir_all(path.parent().ok_or_else(|| {
+            AnchorError::InvalidStructure(format!(
+                "project profile has no parent: {}",
+                path.display()
+            ))
+        })?)?;
+        fs::write(path, serde_json::to_vec_pretty(profile)?)?;
+        Ok(())
+    }
+
+    pub fn load_project_profile(&self) -> Result<Option<ProjectProfile>> {
+        let path = self.project_profile_path();
+        if !path.exists() {
+            return Ok(None);
+        }
+
+        let bytes = fs::read(path)?;
+        Ok(Some(serde_json::from_slice(&bytes)?))
+    }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -10,5 +10,6 @@ pub(crate) mod bm25;
 
 pub use anchor::{
     content_hash, AnchorStore, CallIndex, CoChangeEntry, HistoryIndex, HistoryNeighbor, ObjectKind,
-    PathEntry, PathHistoryEntry, PathIndex, Projection, SymbolEntry, SymbolIndex, ANCHOR_DIR,
+    PathEntry, PathHistoryEntry, PathIndex, ProjectProfile, Projection, SymbolEntry, SymbolIndex,
+    ANCHOR_DIR,
 };

--- a/tests/test_cli_build_parts/part5.rs
+++ b/tests/test_cli_build_parts/part5.rs
@@ -69,3 +69,117 @@ fn cli_context_truncates_large_default_symbol_output() {
     assert!(stdout.contains("context truncated"), "{stdout}");
     assert!(!stdout.contains("print(179)"), "{stdout}");
 }
+
+#[test]
+fn cli_build_writes_project_profile_snapshot() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::create_dir_all(dir.path().join("src")).unwrap();
+    fs::create_dir_all(dir.path().join("lockd")).unwrap();
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        "[package]\nname = \"profile-fixture\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join("src/app.py"),
+        "def repair_prompt():\n    return True\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join("main.go"),
+        "package main\n\nfunc main() {}\n",
+    )
+    .unwrap();
+    fs::write(dir.path().join("lockd/go.mod"), "module example.com/lockd\n").unwrap();
+    fs::write(
+        dir.path().join("package.json"),
+        r#"{"dependencies":{"express":"5.0.0","react":"18.0.0"},"devDependencies":{"jest":"29.0.0"}}"#,
+    )
+    .unwrap();
+
+    let anchor = env!("CARGO_BIN_EXE_anchor");
+    let build = Command::new(anchor)
+        .arg("--root")
+        .arg(dir.path())
+        .arg("build")
+        .output()
+        .unwrap();
+
+    assert!(
+        build.status.success(),
+        "build failed: {}\n{}",
+        String::from_utf8_lossy(&build.stderr),
+        String::from_utf8_lossy(&build.stdout)
+    );
+
+    let profile_path = dir.path().join(".anchor/project_profile.json");
+    let profile: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&profile_path).unwrap()).unwrap();
+
+    assert_eq!(profile["schema"], "anchor.project_profile.v1", "{profile}");
+    assert_eq!(profile["indexed_symbols"], 2, "{profile}");
+    assert!(
+        profile["indexed_files"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|item| item == "src/app.py"),
+        "{profile}"
+    );
+    assert!(
+        profile["indexed_files"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|item| item == "package.json"),
+        "{profile}"
+    );
+    assert!(
+        profile["manifests"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|item| item == "Cargo.toml"),
+        "{profile}"
+    );
+    assert!(
+        profile["test_commands"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|item| item == "cargo test"),
+        "{profile}"
+    );
+    assert!(
+        profile["frameworks_present"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|item| item == "react"),
+        "{profile}"
+    );
+    assert!(
+        profile["frameworks_present"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|item| item == "jest"),
+        "{profile}"
+    );
+    assert!(
+        profile["frameworks_absent"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|item| item == "next"),
+        "{profile}"
+    );
+    assert!(
+        profile["entrypoints"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|item| item == "main.go"),
+        "{profile}"
+    );
+}


### PR DESCRIPTION
## Summary
- persist a deterministic `.anchor/project_profile.json` snapshot during `anchor build`
- reuse that cached profile in `benchmark/prompt_improvement.py` when present instead of rebuilding repo facts from scratch
- document the new prompt-memory cache and add a focused build integration test for the snapshot contents

## Why
Current prompt-repair work on `dev` already depends on compact repo facts, but those facts are recomputed on every benchmark run. A cached project profile gives Anchor a small always-available memory layer for languages, manifests, key files, test commands, indexed files, frameworks, and entrypoints.

## Validation
- `python3 benchmark/prompt_improvement.py --dry-run --limit 1 --repo . --cases benchmark/prompt_cases.example.jsonl --out /tmp/anchor-prompt-profile-smoke.jsonl`
- `git diff --check`

## Not Run
- `cargo test --test test_cli_build cli_build_writes_project_profile_snapshot -- --exact` (`cargo` is not installed in this environment)
- `cargo fmt --check` (`cargo` is not installed in this environment)
