### PR TITLE
Stabilize DeepSWE batch summary parsing

### DIFF
--- a/benchmark/run_deepswe_codex_batch.py
+++ b/benchmark/run_deepswe_codex_batch.py
@@ -17,13 +17,17 @@ DEFAULT_BATCH_ROOT = Path("/Volumes/Hak_SSD/anchor-benchmark-work/native-deepswe
 
 def parse_summary_from_log(log_path: Path) -> dict[str, Any] | None:
     text = log_path.read_text(errors="replace")
-    start = text.find("{")
-    if start < 0:
-        return None
-    try:
-        return json.loads(text[start:])
-    except json.JSONDecodeError:
-        return None
+    decoder = json.JSONDecoder()
+    for start in range(len(text) - 1, -1, -1):
+        if text[start] != "{":
+            continue
+        try:
+            summary, end = decoder.raw_decode(text[start:])
+        except json.JSONDecodeError:
+            continue
+        if isinstance(summary, dict) and not text[start + end :].strip():
+            return summary
+    return None
 
 
 def metric(summary: dict[str, Any], path: list[str], default: Any = None) -> Any:

--- a/benchmark/test_run_deepswe_codex_batch.py
+++ b/benchmark/test_run_deepswe_codex_batch.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from run_deepswe_codex_batch import parse_summary_from_log
+
+
+class RunDeepSweCodexBatchTests(unittest.TestCase):
+    def test_parse_summary_prefers_trailing_json_object(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "stdout.log"
+            trailing_summary = {
+                "schema": "anchor.native_deepswe_codex_batch.v1",
+                "task_id": "demo-task",
+                "aggregate": {"completed": 1},
+            }
+            log_path.write_text(
+                '\n'.join(
+                    [
+                        '[anchor-benchmark] starting',
+                        '{"run": 1, "exit_code": 0}',
+                        json.dumps(trailing_summary, indent=2, sort_keys=True),
+                    ]
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            summary = parse_summary_from_log(log_path)
+
+            self.assertEqual(summary, trailing_summary)
+
+    def test_parse_summary_returns_none_without_valid_trailing_json(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "stdout.log"
+            log_path.write_text(
+                '[anchor-benchmark] starting\n{"run": 1, "exit_code": 0}\nnot json\n',
+                encoding="utf-8",
+            )
+
+            summary = parse_summary_from_log(log_path)
+
+            self.assertIsNone(summary)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- make the DeepSWE batch runner parse the trailing summary object instead of the first JSON fragment in the log
- add unit coverage for logs that contain intermediate JSON lines before the final summary

## Why
The batch runner streams per-run JSON status lines before it prints the final summary. Parsing from the first `{` could drop the real batch summary and leave aggregation looking incomplete even when the runs succeeded.

## Validation
- `python3 -m unittest benchmark/test_run_deepswe_codex_batch.py`
- `python3 -m py_compile benchmark/run_deepswe_codex_batch.py benchmark/test_run_deepswe_codex_batch.py`
- `git diff --check`
