### PR TITLE
Cache prompt memory for repo instruction files

### DIFF
--- a/docs/prompt-repair.md
+++ b/docs/prompt-repair.md
@@ -16,6 +16,7 @@ What exists today:
 
 - a local benchmark harness in `benchmark/prompt_improvement.py`
 - prompt cases in `benchmark/prompt_cases.example.jsonl`
+- `anchor build` caches repo-local instruction files in `.anchor/product_memory.json`
 - deterministic repo profiling from files, manifests, symbols, and `.anchor`
   indexes when available
 - local Ollama smoke testing for raw prompt vs repaired prompt
@@ -78,6 +79,7 @@ anchor build
   -> .anchor/index/paths.json
   -> .anchor/index/symbols.json
   -> .anchor/index/calls.json
+  -> .anchor/product_memory.json
   -> .anchor/project_profile.json
 
 anchor prompt repair "<human prompt>"

--- a/src/bin/cli_parts/build.rs
+++ b/src/bin/cli_parts/build.rs
@@ -11,6 +11,8 @@ struct BuildStats {
     history_edges: usize,
 }
 
+const PRODUCT_MEMORY_SCHEMA: &str = "anchor.product_memory.v1";
+
 fn cmd_build(root: &Path) -> Result<()> {
     let stats = build_indexes(root)?;
     print_build_stats(stats);
@@ -19,7 +21,10 @@ fn cmd_build(root: &Path) -> Result<()> {
 
 fn build_indexes(root: &Path) -> Result<BuildStats> {
     use anchor::storage::content_hash;
-    use anchor::storage::{CallIndex, PathEntry, PathIndex, SymbolEntry, SymbolIndex};
+    use anchor::storage::{
+        CallIndex, PathEntry, PathIndex, ProductMemory, ProductMemoryFile, SymbolEntry,
+        SymbolIndex,
+    };
     use std::collections::HashMap;
     use std::fs;
 
@@ -152,6 +157,7 @@ fn build_indexes(root: &Path) -> Result<BuildStats> {
     store.save_call_index(&call_index)?;
     let history_index = build_history_index(root);
     store.save_history_index(&history_index)?;
+    store.save_product_memory(&build_product_memory(root)?)?;
 
     let indexed = results.len();
     let skipped = files.len() - indexed;
@@ -170,3 +176,149 @@ fn build_indexes(root: &Path) -> Result<BuildStats> {
     })
 }
 
+fn build_product_memory(root: &Path) -> Result<ProductMemory> {
+    let mut instruction_files = Vec::new();
+
+    for (path, kind, note) in [
+        (
+            "AGENTS.md",
+            "agent_rules",
+            "Repo-local agent instructions for coding sessions.",
+        ),
+        (
+            "CLAUDE.md",
+            "agent_rules",
+            "Repo-local Claude guidance that prompt repair should preserve.",
+        ),
+        (
+            "GEMINI.md",
+            "agent_rules",
+            "Repo-local Gemini guidance that prompt repair should preserve.",
+        ),
+        (
+            ".github/copilot-instructions.md",
+            "copilot_rules",
+            "GitHub Copilot repository instructions.",
+        ),
+        (
+            ".clinerules",
+            "cline_rules",
+            "Cline repository rules for agent behavior.",
+        ),
+        (
+            ".cursorrules",
+            "cursor_rules",
+            "Cursor repository rules for agent behavior.",
+        ),
+        (
+            ".windsurfrules",
+            "windsurf_rules",
+            "Windsurf repository rules for agent behavior.",
+        ),
+    ] {
+        add_instruction_file(root, path, kind, note, &mut instruction_files)?;
+    }
+
+    collect_instruction_dir(
+        root,
+        ".cursor/rules",
+        "cursor_rule",
+        "Cursor rule file that prompt repair should preserve.",
+        &mut instruction_files,
+    )?;
+    collect_instruction_dir(
+        root,
+        ".continue/rules",
+        "continue_rule",
+        "Continue rule file that prompt repair should preserve.",
+        &mut instruction_files,
+    )?;
+    collect_instruction_dir(
+        root,
+        ".continue/prompts",
+        "continue_prompt",
+        "Continue prompt file that may shape repo-local agent behavior.",
+        &mut instruction_files,
+    )?;
+
+    instruction_files.sort_by(|a, b| a.path.cmp(&b.path));
+    Ok(ProductMemory {
+        schema: PRODUCT_MEMORY_SCHEMA.to_string(),
+        instruction_files,
+    })
+}
+
+fn add_instruction_file(
+    root: &Path,
+    relative: &str,
+    kind: &str,
+    note: &str,
+    out: &mut Vec<ProductMemoryFile>,
+) -> Result<()> {
+    use std::fs;
+
+    let path = root.join(relative);
+    if !path.is_file() {
+        return Ok(());
+    }
+
+    let bytes = fs::read(&path)?;
+    out.push(ProductMemoryFile {
+        path: relative.replace('\\', "/"),
+        kind: kind.to_string(),
+        note: note.to_string(),
+        source_hash: content_hash(&bytes),
+    });
+    Ok(())
+}
+
+fn collect_instruction_dir(
+    root: &Path,
+    relative_dir: &str,
+    kind: &str,
+    note: &str,
+    out: &mut Vec<ProductMemoryFile>,
+) -> Result<()> {
+    use std::fs;
+
+    let dir = root.join(relative_dir);
+    if !dir.is_dir() {
+        return Ok(());
+    }
+
+    let mut stack = vec![dir];
+    while let Some(current) = stack.pop() {
+        for entry in fs::read_dir(&current)? {
+            let entry = entry?;
+            let path = entry.path();
+            let file_type = entry.file_type()?;
+            if file_type.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            if !file_type.is_file() || !looks_like_instruction_text(&path) {
+                continue;
+            }
+
+            let relative = path
+                .strip_prefix(root)
+                .map(|value| value.to_string_lossy().replace('\\', "/"))?;
+            let bytes = fs::read(&path)?;
+            out.push(ProductMemoryFile {
+                path: relative,
+                kind: kind.to_string(),
+                note: note.to_string(),
+                source_hash: content_hash(&bytes),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+fn looks_like_instruction_text(path: &Path) -> bool {
+    matches!(
+        path.extension().and_then(|ext| ext.to_str()),
+        Some("md" | "mdc" | "txt" | "json" | "yaml" | "yml")
+    )
+}

--- a/src/storage/anchor.rs
+++ b/src/storage/anchor.rs
@@ -138,6 +138,21 @@ pub struct Projection {
     pub text: String,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProductMemory {
+    pub schema: String,
+    #[serde(default)]
+    pub instruction_files: Vec<ProductMemoryFile>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProductMemoryFile {
+    pub path: String,
+    pub kind: String,
+    pub note: String,
+    pub source_hash: String,
+}
+
 include!("anchor_parts/store_core.rs");
 include!("anchor_parts/index_io.rs");
 include!("anchor_parts/symbol_update.rs");

--- a/src/storage/anchor_parts/index_io.rs
+++ b/src/storage/anchor_parts/index_io.rs
@@ -1,4 +1,30 @@
 impl AnchorStore {
+    pub fn product_memory_path(&self) -> PathBuf {
+        self.anchor_root.join("product_memory.json")
+    }
+
+    pub fn load_product_memory(&self) -> Result<ProductMemory> {
+        let path = self.product_memory_path();
+        if !path.exists() {
+            return Ok(ProductMemory::default());
+        }
+
+        let bytes = fs::read(path)?;
+        Ok(serde_json::from_slice(&bytes)?)
+    }
+
+    pub fn save_product_memory(&self, memory: &ProductMemory) -> Result<()> {
+        let path = self.product_memory_path();
+        fs::create_dir_all(path.parent().ok_or_else(|| {
+            AnchorError::InvalidStructure(format!(
+                "product memory has no parent: {}",
+                path.display()
+            ))
+        })?)?;
+        fs::write(path, serde_json::to_vec_pretty(memory)?)?;
+        Ok(())
+    }
+
     pub fn path_index_path(&self) -> PathBuf {
         self.anchor_root.join("index").join("paths.json")
     }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -10,5 +10,6 @@ pub(crate) mod bm25;
 
 pub use anchor::{
     content_hash, AnchorStore, CallIndex, CoChangeEntry, HistoryIndex, HistoryNeighbor, ObjectKind,
-    PathEntry, PathHistoryEntry, PathIndex, Projection, SymbolEntry, SymbolIndex, ANCHOR_DIR,
+    PathEntry, PathHistoryEntry, PathIndex, ProductMemory, ProductMemoryFile, Projection,
+    SymbolEntry, SymbolIndex, ANCHOR_DIR,
 };

--- a/tests/test_cli_build_parts/part5.rs
+++ b/tests/test_cli_build_parts/part5.rs
@@ -69,3 +69,83 @@ fn cli_context_truncates_large_default_symbol_output() {
     assert!(stdout.contains("context truncated"), "{stdout}");
     assert!(!stdout.contains("print(179)"), "{stdout}");
 }
+
+#[test]
+fn cli_build_writes_instruction_file_product_memory() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::create_dir_all(dir.path().join(".cursor/rules")).unwrap();
+    fs::create_dir_all(dir.path().join(".continue/rules")).unwrap();
+    fs::create_dir_all(dir.path().join(".github")).unwrap();
+    fs::write(dir.path().join("src.py"), "def repair():\n    return True\n").unwrap();
+    fs::write(
+        dir.path().join("AGENTS.md"),
+        "# Repo rules\nAlways inspect tests before editing.\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join("CLAUDE.md"),
+        "# Claude rules\nStay grounded in repo files.\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join(".cursor/rules/prompt-repair.mdc"),
+        "# Cursor rule\nPrefer prompt repair evidence.\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join(".continue/rules/repair.md"),
+        "# Continue rule\nKeep edits scoped.\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join(".github/copilot-instructions.md"),
+        "# Copilot\nUse repo-local checks.\n",
+    )
+    .unwrap();
+
+    let anchor = env!("CARGO_BIN_EXE_anchor");
+    let build = Command::new(anchor)
+        .arg("--root")
+        .arg(dir.path())
+        .arg("build")
+        .output()
+        .unwrap();
+    assert!(
+        build.status.success(),
+        "build failed: {}\n{}",
+        String::from_utf8_lossy(&build.stderr),
+        String::from_utf8_lossy(&build.stdout)
+    );
+
+    let memory_path = dir.path().join(".anchor/product_memory.json");
+    let memory = fs::read_to_string(&memory_path)
+        .unwrap_or_else(|e| panic!("missing product memory {}: {e}", memory_path.display()));
+    let json: serde_json::Value = serde_json::from_str(&memory).unwrap();
+    assert_eq!(json["schema"], "anchor.product_memory.v1", "{memory}");
+
+    let files = json["instruction_files"].as_array().unwrap();
+    let paths = files
+        .iter()
+        .map(|item| item["path"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        paths,
+        vec![
+            ".continue/rules/repair.md",
+            ".cursor/rules/prompt-repair.mdc",
+            ".github/copilot-instructions.md",
+            "AGENTS.md",
+            "CLAUDE.md",
+        ],
+        "{memory}"
+    );
+
+    for item in files {
+        let kind = item["kind"].as_str().unwrap();
+        let note = item["note"].as_str().unwrap();
+        let source_hash = item["source_hash"].as_str().unwrap();
+        assert!(!kind.is_empty(), "{memory}");
+        assert!(note.contains("instruction") || note.contains("prompt repair"), "{memory}");
+        assert_eq!(source_hash.len(), 64, "{memory}");
+    }
+}


### PR DESCRIPTION
## Summary
- write `.anchor/product_memory.json` during `anchor build`
- cache common repo instruction files such as `AGENTS.md`, Copilot instructions, and Cursor/Continue rule files
- add a build integration test and prompt-repair docs for the new instruction-file memory

## Validation
- `git diff --check`

## Not Run
- `cargo test --test test_cli_build cli_build_writes_instruction_file_product_memory -- --exact` (`cargo` is not installed in this environment)
- `cargo fmt --check` (`cargo` is not installed in this environment)
