### PR TITLE
Handle nested DeepSWE trial result discovery

### DIFF
--- a/benchmark/collect_deepswe_compare.py
+++ b/benchmark/collect_deepswe_compare.py
@@ -21,7 +21,12 @@ def first_existing(paths: list[Path]) -> Path | None:
 
 
 def first_trial_result(job_dir: Path) -> dict[str, Any] | None:
-    for path in sorted([*job_dir.glob("*/result.json"), *job_dir.glob("**/results.json")]):
+    candidates = {
+        *job_dir.glob("*/result.json"),
+        *job_dir.glob("**/result.json"),
+        *job_dir.glob("**/results.json"),
+    }
+    for path in sorted(candidates):
         data = load_json(path)
         if data and ("task_name" in data or "trial_name" in data):
             return data

--- a/benchmark/test_collect_deepswe_compare.py
+++ b/benchmark/test_collect_deepswe_compare.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from collect_deepswe_compare import first_trial_result, trace_summary
+
+
+class CollectDeepSWECompareTests(unittest.TestCase):
+    def test_first_trial_result_reads_nested_result_json(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            job_dir = Path(tmp)
+            nested = job_dir / "runs" / "trial-001"
+            nested.mkdir(parents=True)
+            (nested / "result.json").write_text(
+                json.dumps(
+                    {
+                        "task_name": "python-statemachine-state-data-scoping",
+                        "trial_name": "anchor",
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            result = first_trial_result(job_dir)
+
+            self.assertIsNotNone(result)
+            self.assertEqual(result["task_name"], "python-statemachine-state-data-scoping")
+            self.assertEqual(result["trial_name"], "anchor")
+
+    def test_trace_summary_counts_anchor_usage_flags(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            trace = Path(tmp) / "trace.jsonl"
+            trace.write_text(
+                "\n".join(
+                    [
+                        json.dumps(
+                            {
+                                "classification": {
+                                    "uses_anchor": True,
+                                    "runs_tests": True,
+                                    "raw_read": False,
+                                    "raw_write": False,
+                                }
+                            }
+                        ),
+                        json.dumps(
+                            {
+                                "classification": {
+                                    "uses_anchor": False,
+                                    "runs_tests": False,
+                                    "raw_read": True,
+                                    "raw_write": True,
+                                    "source_like": True,
+                                }
+                            }
+                        ),
+                    ]
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            summary = trace_summary(trace)
+
+            self.assertEqual(
+                summary,
+                {
+                    "events": 2,
+                    "uses_anchor": 1,
+                    "runs_tests": 1,
+                    "raw_reads": 1,
+                    "raw_writes": 1,
+                    "source_like_raw_writes": 1,
+                },
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- broaden `collect_deepswe_compare.py` trial discovery to include nested `result.json` files as well as nested `results.json`
- deduplicate candidate paths before sorting so the collector only inspects each result file once
- add a regression test for nested trial outputs plus a small trace counter test

## Why
DeepSWE pair runners write per-trial `result.json` files under nested run directories. The collector only looked for one-level `result.json` paths and recursive `results.json`, so some valid trial outputs were skipped and the comparison summary could miss the actual task metadata.

## Validation
- `python3 -m unittest benchmark/test_collect_deepswe_compare.py`
- `python3 -m py_compile benchmark/collect_deepswe_compare.py benchmark/test_collect_deepswe_compare.py`
- `git diff --check`