### PR TITLE
Handle nested DeepSWE trial results and improve discovery

### DIFF
--- a/benchmark/collect_deepswe_compare.py
+++ b/benchmark/collect_deepswe_compare.py
@@ -21,7 +21,12 @@ def first_existing(paths: list[Path]) -> Path | None:
 
 
 def first_trial_result(job_dir: Path) -> dict[str, Any] | None:
-    for path in sorted([*job_dir.glob("*/result.json"), *job_dir.glob("**/results.json")]):
+    candidates = {
+        *job_dir.glob("*/result.json"),
+        *job_dir.glob("**/result.json"),
+        *job_dir.glob("**/results.json"),
+    }
+    for path in sorted(candidates):
         data = load_json(path)
         if data and ("task_name" in data or "trial_name" in data):
             return data

--- a/benchmark/test_collect_deepswe_compare.py
+++ b/benchmark/test_collect_deepswe_compare.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from collect_deepswe_compare import first_trial_result, trace_summary
+
+
+class CollectDeepSWECompareTests(unittest.TestCase):
+    def test_first_trial_result_reads_nested_result_json(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            job_dir = Path(tmp)
+            nested = job_dir / "runs" / "trial-001"
+            nested.mkdir(parents=True)
+            (nested / "result.json").write_text(
+                json.dumps(
+                    {
+                        "task_name": "python-statemachine-state-data-scoping",
+                        "trial_name": "anchor",
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            result = first_trial_result(job_dir)
+
+            self.assertIsNotNone(result)
+            self.assertEqual(result["task_name"], "python-statemachine-state-data-scoping")
+            self.assertEqual(result["trial_name"], "anchor")
+
+    def test_trace_summary_counts_anchor_usage_flags(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            trace = Path(tmp) / "trace.jsonl"
+            trace.write_text(
+                "\n".join(
+                    [
+                        json.dumps(
+                            {
+                                "classification": {
+                                    "uses_anchor": True,
+                                    "runs_tests": True,
+                                    "raw_read": False,
+                                    "raw_write": False,
+                                }
+                            }
+                        ),
+                        json.dumps(
+                            {
+                                "classification": {
+                                    "uses_anchor": False,
+                                    "runs_tests": False,
+                                    "raw_read": True,
+                                    "raw_write": True,
+                                    "source_like": True,
+                                }
+                            }
+                        ),
+                    ]
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            summary = trace_summary(trace)
+
+            self.assertEqual(
+                summary,
+                {
+                    "events": 2,
+                    "uses_anchor": 1,
+                    "runs_tests": 1,
+                    "raw_reads": 1,
+                    "raw_writes": 1,
+                    "source_like_raw_writes": 1,
+                },
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved result file discovery so nested trial results are found more reliably, including both singular and plural result file names.
  * Made summary generation more robust when processing trace data with different event patterns.

* **Tests**
  * Added coverage for nested result-file loading.
  * Added coverage for trace summary counting, including anchor usage and raw read/write metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->