### PR TITLE
Use call index in prompt benchmark

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -13,8 +13,9 @@ Current goal:
 
 `benchmark/prompt_improvement.py` tests the project-aware prompt-repair idea
 with local Ollama. It compares a raw human prompt against an Anchor-repaired
-prompt that includes verified project facts, likely files, risky assumptions,
-and checks to run.
+prompt that includes verified project facts, likely files, optional
+call-neighborhood hints from `.anchor/index/calls.json`, risky assumptions, and
+checks to run.
 
 For product design and the planned Rust CLI, see
 [Project-Aware Prompt Repair](../docs/prompt-repair.md).

--- a/benchmark/prompt_improvement.py
+++ b/benchmark/prompt_improvement.py
@@ -124,6 +124,8 @@ class ProjectProfile:
     manifest_files: list[str]
     test_commands: list[str]
     symbols: list[str]
+    symbol_paths: dict[str, list[str]]
+    call_index: dict[str, list[str]]
 
 
 @dataclass
@@ -251,28 +253,39 @@ def detect_manifest_files(root: Path) -> list[str]:
     return [file for file in candidates if (root / file).exists()]
 
 
-def load_anchor_index(root: Path) -> tuple[list[str], list[str]]:
+def append_symbol_path(mapping: dict[str, list[str]], symbol_name: str, path: str) -> None:
+    key = symbol_name.lower()
+    paths = mapping.setdefault(key, [])
+    if path not in paths:
+        paths.append(path)
+
+
+def load_anchor_index(root: Path) -> tuple[list[str], list[str], dict[str, list[str]]]:
     """Use Anchor's generated symbol index when this repo has been built."""
     path = root / ".anchor" / "index" / "symbols.json"
     if not path.exists():
-        return [], []
+        return [], [], {}
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
-        return [], []
+        return [], [], {}
 
     indexed_files: set[str] = set()
     symbols: list[str] = []
+    symbol_paths: dict[str, list[str]] = {}
     for item in data.get("symbols", []):
         name = item.get("name")
         file = item.get("path")
         if isinstance(name, str) and isinstance(file, str):
             indexed_files.add(file)
             symbols.append(f"{name} ({file})")
-    return sorted(indexed_files), symbols[:120]
+            append_symbol_path(symbol_paths, name, file)
+    return sorted(indexed_files), symbols[:120], symbol_paths
 
 
-def extract_symbols(root: Path, files: list[Path], limit: int = 120) -> list[str]:
+def extract_symbols(
+    root: Path, files: list[Path], limit: int = 120
+) -> tuple[list[str], dict[str, list[str]]]:
     patterns = [
         re.compile(r"^\s*(?:pub\s+)?(?:async\s+)?fn\s+([A-Za-z_][A-Za-z0-9_]*)"),
         re.compile(r"^\s*(?:pub\s+)?(?:struct|enum|trait)\s+([A-Za-z_][A-Za-z0-9_]*)"),
@@ -281,6 +294,7 @@ def extract_symbols(root: Path, files: list[Path], limit: int = 120) -> list[str
         re.compile(r"^\s*(?:export\s+)?(?:async\s+)?function\s+([A-Za-z_][A-Za-z0-9_]*)"),
     ]
     symbols: list[str] = []
+    symbol_paths: dict[str, list[str]] = {}
     for rel in files:
         if rel.suffix not in {".rs", ".go", ".py", ".js", ".ts", ".tsx"}:
             continue
@@ -292,11 +306,37 @@ def extract_symbols(root: Path, files: list[Path], limit: int = 120) -> list[str
             for pattern in patterns:
                 match = pattern.search(line)
                 if match:
-                    symbols.append(f"{match.group(1)} ({rel.as_posix()})")
+                    symbol_name = match.group(1)
+                    rel_path = rel.as_posix()
+                    symbols.append(f"{symbol_name} ({rel_path})")
+                    append_symbol_path(symbol_paths, symbol_name, rel_path)
                     break
             if len(symbols) >= limit:
-                return symbols
-    return symbols
+                return symbols, symbol_paths
+    return symbols, symbol_paths
+
+
+def load_call_index(root: Path) -> dict[str, list[str]]:
+    path = root / ".anchor" / "index" / "calls.json"
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+    raw_calls = data.get("calls", {})
+    if not isinstance(raw_calls, dict):
+        return {}
+
+    call_index: dict[str, list[str]] = {}
+    for caller, callees in raw_calls.items():
+        if not isinstance(caller, str) or not isinstance(callees, list):
+            continue
+        normalized = [callee for callee in callees if isinstance(callee, str) and callee.strip()]
+        if normalized:
+            call_index[caller.lower()] = normalized
+    return call_index
 
 
 def split_tokens(text: str) -> set[str]:
@@ -311,7 +351,7 @@ def split_tokens(text: str) -> set[str]:
 
 def build_profile(root: Path) -> ProjectProfile:
     files = repo_files(root)
-    indexed_files, indexed_symbols = load_anchor_index(root)
+    indexed_files, indexed_symbols, indexed_symbol_paths = load_anchor_index(root)
     language_counts = Counter(
         LANG_BY_EXT[path.suffix] for path in files if path.suffix in LANG_BY_EXT
     )
@@ -331,6 +371,7 @@ def build_profile(root: Path) -> ProjectProfile:
         ]
         if (root / file).exists()
     ]
+    extracted_symbols, extracted_symbol_paths = extract_symbols(root, files)
     return ProjectProfile(
         root=str(root),
         languages=[name for name, _ in language_counts.most_common(8)],
@@ -339,7 +380,9 @@ def build_profile(root: Path) -> ProjectProfile:
         indexed_files=indexed_files,
         manifest_files=detect_manifest_files(root),
         test_commands=detect_test_commands(root),
-        symbols=indexed_symbols or extract_symbols(root, files),
+        symbols=indexed_symbols or extracted_symbols,
+        symbol_paths=indexed_symbol_paths or extracted_symbol_paths,
+        call_index=load_call_index(root),
     )
 
 
@@ -370,6 +413,7 @@ def matching_project_targets(prompt: str, profile: ProjectProfile) -> list[Targe
     hits: list[TargetHint] = []
     prompt_tokens = split_tokens(prompt)
     candidate_files = sorted(set(profile.key_files + profile.indexed_files))
+    matched_symbols: set[str] = set()
 
     for file in candidate_files:
         overlap = sorted(prompt_tokens & split_tokens(file))
@@ -385,7 +429,32 @@ def matching_project_targets(prompt: str, profile: ProjectProfile) -> list[Targe
     for symbol in profile.symbols:
         name = symbol.split(" ", 1)[0].lower()
         if len(name) > 3 and name in text:
+            matched_symbols.add(name)
             hits.append(TargetHint(symbol, f"prompt mentions symbol-like term {name!r}"))
+    for name in sorted(matched_symbols):
+        for path in profile.symbol_paths.get(name, []):
+            hits.append(TargetHint(path, f"verified: symbol {name!r} is defined here"))
+        for callee in profile.call_index.get(name, [])[:4]:
+            for path in profile.symbol_paths.get(callee.lower(), []):
+                hits.append(
+                    TargetHint(
+                        path,
+                        f"verified: {name!r} calls symbol {callee!r} in this file",
+                    )
+                )
+        callers = [
+            caller
+            for caller, callees in profile.call_index.items()
+            if any(callee.lower() == name for callee in callees)
+        ]
+        for caller in callers[:4]:
+            for path in profile.symbol_paths.get(caller.lower(), []):
+                hits.append(
+                    TargetHint(
+                        path,
+                        f"verified: symbol {caller!r} calls matched symbol {name!r}",
+                    )
+                )
     if any(word in text for word in ["lock", "locks", "agent", "agents", "same file"]):
         for path, reason in [
             ("src/cli/write.rs", "write path acquires file/symbol locks"),

--- a/benchmark/test_prompt_improvement_call_index.py
+++ b/benchmark/test_prompt_improvement_call_index.py
@@ -1,0 +1,74 @@
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("prompt_improvement.py")
+SPEC = importlib.util.spec_from_file_location("prompt_improvement", MODULE_PATH)
+prompt_improvement = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = prompt_improvement
+SPEC.loader.exec_module(prompt_improvement)
+
+
+class PromptImprovementCallIndexTests(unittest.TestCase):
+    def create_repo(self) -> Path:
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        root = Path(tmp.name)
+        (root / "Cargo.toml").write_text(
+            "[package]\nname = 'demo'\nversion = '0.1.0'\n",
+            encoding="utf-8",
+        )
+        (root / "src").mkdir()
+        (root / "src" / "auth.rs").write_text("pub fn login() {}\n", encoding="utf-8")
+        (root / "src" / "session.rs").write_text(
+            "pub fn establish_session() {}\n",
+            encoding="utf-8",
+        )
+        (root / ".anchor" / "index").mkdir(parents=True)
+        (root / ".anchor" / "index" / "symbols.json").write_text(
+            json.dumps(
+                {
+                    "symbols": [
+                        {"name": "login", "path": "src/auth.rs"},
+                        {"name": "establish_session", "path": "src/session.rs"},
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        (root / ".anchor" / "index" / "calls.json").write_text(
+            json.dumps({"calls": {"login": ["establish_session"]}}),
+            encoding="utf-8",
+        )
+        return root
+
+    def test_build_profile_loads_call_index(self) -> None:
+        profile = prompt_improvement.build_profile(self.create_repo())
+
+        self.assertEqual(profile.call_index, {"login": ["establish_session"]})
+        self.assertEqual(profile.symbol_paths["login"], ["src/auth.rs"])
+
+    def test_matching_targets_adds_call_neighbor_files(self) -> None:
+        profile = prompt_improvement.build_profile(self.create_repo())
+
+        targets = prompt_improvement.matching_project_targets("Fix the login flow", profile)
+        target_paths = {target.path for target in targets}
+
+        self.assertIn("src/auth.rs", target_paths)
+        self.assertIn("src/session.rs", target_paths)
+        self.assertTrue(
+            any(
+                "calls symbol" in target.reason
+                for target in targets
+                if target.path == "src/session.rs"
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/prompt-repair.md
+++ b/docs/prompt-repair.md
@@ -18,6 +18,8 @@ What exists today:
 - prompt cases in `benchmark/prompt_cases.example.jsonl`
 - deterministic repo profiling from files, manifests, symbols, and `.anchor`
   indexes when available
+- optional call-neighborhood routing from `.anchor/index/calls.json` when the
+  repo has been built with Anchor
 - local Ollama smoke testing for raw prompt vs repaired prompt
 
 What is not implemented yet:
@@ -169,7 +171,7 @@ Find likely targets using:
 - symbol index matches
 - BM25-style feature tokens
 - manifest/test-command evidence
-- optional call-neighborhood hints from `calls.json`
+- optional call-neighborhood hints from `.anchor/index/calls.json`
 
 Each target should carry an evidence label:
 


### PR DESCRIPTION
## Summary
- load `.anchor/index/calls.json` into the prompt benchmark profile when an Anchor build has produced a call index
- add caller/callee neighbor files as verified target hints when the prompt names a known symbol
- document the routing signal and add focused unit coverage for call-index loading and hint expansion

## Why
Recent repo-memory and prompt-grounding patterns consistently combine repo facts with structural retrieval rather than flat file lists alone. Anchor's prompt-repair docs already called out call-neighborhood routing, but the `dev` benchmark path was still ignoring `.anchor/index/calls.json` entirely.

## Validation
- `python3 -m unittest benchmark.test_prompt_improvement_call_index`
- `python3 -m py_compile benchmark/prompt_improvement.py benchmark/test_prompt_improvement_call_index.py`
- `python3 benchmark/prompt_improvement.py --dry-run --limit 1 --repo . --cases benchmark/prompt_cases.example.jsonl --out /tmp/anchor-prompt-call-hints.jsonl`
- `git diff --check`
